### PR TITLE
feat/Add LineItems to Anonymous Cart

### DIFF
--- a/e-commerce/src/app/pages/product/product.component.html
+++ b/e-commerce/src/app/pages/product/product.component.html
@@ -23,7 +23,7 @@
         {{ discountPercnt > 0 ? (discuntedPrice | currency) : (originalPrice | currency) }}
       </p>
       <div class="button-container">
-        <button>
+        <button (click)="addToCart()">
           <img src="../../../assets/cart.svg" width="18" height="18" alt="cart" />
           <span>Buy</span>
         </button>

--- a/e-commerce/src/app/pages/product/product.component.ts
+++ b/e-commerce/src/app/pages/product/product.component.ts
@@ -8,6 +8,7 @@ import SliderComponent from './slider/slider.component';
 import { AppState } from '../../store/store';
 import { Product, CategoriesArray } from '../../shared/services/products/productTypes';
 import * as actions from '../../store/actions';
+import { CartBase } from '../../shared/services/commercetoolsApi/apitypes';
 
 @Component({
   selector: 'app-product',
@@ -17,6 +18,8 @@ import * as actions from '../../store/actions';
   styleUrl: './product.component.scss',
 })
 export default class ProductComponent {
+  cartBase!: CartBase;
+
   productObjects$!: Observable<Product | null>;
 
   categoryObjects$!: Observable<CategoriesArray | null>;
@@ -84,6 +87,17 @@ export default class ProductComponent {
         this.getCategory();
       }
     });
+    this.store
+      .select((state) => state.app.cartBase)
+      .subscribe((cartBase) => {
+        if (cartBase) {
+          this.cartBase = cartBase;
+        }
+      });
+  }
+
+  addToCart() {
+    this.store.dispatch(actions.loadUpdateAnonymousCart({ productId: this.productID, cartBase: this.cartBase }));
   }
 
   getCategory() {

--- a/e-commerce/src/app/shared/services/cart/cart.service.spec.ts
+++ b/e-commerce/src/app/shared/services/cart/cart.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import CartService from './cart.service';
+
+describe('CartService', () => {
+  let service: CartService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CartService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/e-commerce/src/app/shared/services/cart/cart.service.ts
+++ b/e-commerce/src/app/shared/services/cart/cart.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { unauthVisitorAPI } from '../../../../environment';
+import { CartBase } from '../commercetoolsApi/apitypes';
+
+@Injectable({
+  providedIn: 'root',
+})
+export default class CartService {
+  anonToken$!: Observable<string>;
+
+  anonymousId$!: Observable<string | undefined>;
+
+  constructor(private http: HttpClient) {}
+
+  createAnonymousCart(accessToken: string): Observable<CartBase> {
+    const apiUrl = `${unauthVisitorAPI.ctpApiUrl}/${unauthVisitorAPI.ctpProjectKey}/me/carts`;
+
+    const body = {
+      currency: 'USD',
+    };
+
+    const headers = new HttpHeaders()
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    return this.http.post<CartBase>(apiUrl, body, { headers });
+  }
+
+  updateAnonymousCart(accessToken: string, idCart: string, version: number, productId: string): Observable<CartBase> {
+    const apiUrl = `${unauthVisitorAPI.ctpApiUrl}/${unauthVisitorAPI.ctpProjectKey}/me/carts/${idCart}`;
+
+    const body = {
+      version,
+      actions: [
+        {
+          action: 'setCountry',
+          country: 'US',
+        },
+        {
+          action: 'addLineItem',
+          productId,
+          quantity: 1,
+        },
+      ],
+    };
+
+    const headers = new HttpHeaders()
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    return this.http.post<CartBase>(apiUrl, body, { headers });
+  }
+}

--- a/e-commerce/src/app/shared/services/commercetoolsApi/commercetoolsapi.service.ts
+++ b/e-commerce/src/app/shared/services/commercetoolsApi/commercetoolsapi.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, mergeMap } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { authVisitorAPI, unauthVisitorAPI } from '../../../../environment';
-import { Address, AuthData, CartBase, CustomerDraft, CustomerInfo, PasswordChange, PersonalInfo } from './apitypes';
+import { Address, AuthData, CustomerDraft, CustomerInfo, PasswordChange, PersonalInfo } from './apitypes';
 import TokenStorageService from '../tokenStorage/tokenstorage.service';
 import * as actions from '../../../store/actions';
 import { AppState } from '../../../store/store';
@@ -33,45 +33,6 @@ export default class CommerceApiService {
       .set('Authorization', `Basic ${btoa(`${unauthVisitorAPI.ctpClientId}:${unauthVisitorAPI.ctpClientSecret}`)}`);
 
     return this.http.post<AuthData>(unAuthUrl, body.toString(), { headers });
-  }
-
-  createAnonymousCart(accessToken: string): Observable<CartBase> {
-    const apiUrl = `${unauthVisitorAPI.ctpApiUrl}/${unauthVisitorAPI.ctpProjectKey}/me/carts`;
-
-    const body = {
-      currency: 'USD',
-    };
-
-    const headers = new HttpHeaders()
-      .set('Content-Type', 'application/json')
-      .set('Authorization', `Bearer ${accessToken}`);
-
-    return this.http.post<CartBase>(apiUrl, body, { headers });
-  }
-
-  updateAnonymousCart(accessToken: string, idCart: string, version: number, productId: string): Observable<CartBase> {
-    const apiUrl = `${unauthVisitorAPI.ctpApiUrl}/${unauthVisitorAPI.ctpProjectKey}/me/carts/${idCart}`;
-
-    const body = {
-      version,
-      actions: [
-        {
-          action: 'setCountry',
-          country: 'US',
-        },
-        {
-          action: 'addLineItem',
-          productId,
-          quantity: 1,
-        },
-      ],
-    };
-
-    const headers = new HttpHeaders()
-      .set('Content-Type', 'application/json')
-      .set('Authorization', `Bearer ${accessToken}`);
-
-    return this.http.post<CartBase>(apiUrl, body, { headers });
   }
 
   registration(customerDraft: CustomerDraft, anonToken: string, anonymousId: string = ''): Observable<CustomerDraft> {

--- a/e-commerce/src/app/shared/services/commercetoolsApi/commercetoolsapi.service.ts
+++ b/e-commerce/src/app/shared/services/commercetoolsApi/commercetoolsapi.service.ts
@@ -49,6 +49,31 @@ export default class CommerceApiService {
     return this.http.post<CartBase>(apiUrl, body, { headers });
   }
 
+  updateAnonymousCart(accessToken: string, idCart: string, version: number, productId: string): Observable<CartBase> {
+    const apiUrl = `${unauthVisitorAPI.ctpApiUrl}/${unauthVisitorAPI.ctpProjectKey}/me/carts/${idCart}`;
+
+    const body = {
+      version,
+      actions: [
+        {
+          action: 'setCountry',
+          country: 'US',
+        },
+        {
+          action: 'addLineItem',
+          productId,
+          quantity: 1,
+        },
+      ],
+    };
+
+    const headers = new HttpHeaders()
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    return this.http.post<CartBase>(apiUrl, body, { headers });
+  }
+
   registration(customerDraft: CustomerDraft, anonToken: string, anonymousId: string = ''): Observable<CustomerDraft> {
     const apiUrl = `${unauthVisitorAPI.ctpApiUrl}/${unauthVisitorAPI.ctpProjectKey}/customers`;
     const body = {

--- a/e-commerce/src/app/store/actions.ts
+++ b/e-commerce/src/app/store/actions.ts
@@ -87,7 +87,22 @@ export const loadUpdateUserAddressesFailure = createAction(
   '[User] Load Updating User Addresses',
   props<{ error: string }>(),
 );
-
+export const loadUpdateAnonymousCart = createAction(
+  '[Cart] Load Updating Cart Anonymous',
+  props<{
+    productId: string;
+    cartBase: CartBase;
+  }>(),
+);
+export const loadUpdateAnonymousCartSuccess = createAction(
+  '[Cart] Load Updating Cart Anonymous Success',
+  props<{ cartBase: CartBase }>(),
+);
+export const loadUpdateAnonymousCartFailure = createAction(
+  '[Cart] Load Updating Cart Anonymous Failure',
+  props<{ error: string }>(),
+);
+///
 export const loadAnonymousCartSuccess = createAction(
   '[Cart] Cart Anonymous Id Success',
   props<{ cartBase: CartBase }>(),

--- a/e-commerce/src/app/store/effects.ts
+++ b/e-commerce/src/app/store/effects.ts
@@ -23,6 +23,7 @@ import { AppState } from './store';
 import { selectAccessToken, selectAnonymousToken, selectCartAnonId } from './selectors';
 import { NotificationService } from '../shared/services/notification/notification.service';
 import ProductsService from '../shared/services/products/products.service';
+import CartService from '../shared/services/cart/cart.service';
 import {
   CategoriesArray,
   Product,
@@ -36,6 +37,7 @@ export default class EcommerceEffects {
     private actions$: Actions,
     private ecommerceApiService: CommerceApiService,
     private productsService: ProductsService,
+    private cartService: CartService,
     private tokenStorageService: TokenStorageService,
     private notificationService: NotificationService,
     private store: Store<AppState>,
@@ -100,7 +102,7 @@ export default class EcommerceEffects {
     this.actions$.pipe(
       ofType(actions.loadAnonymousTokenSuccess),
       mergeMap((action) => {
-        return this.ecommerceApiService.createAnonymousCart(action.anonymousToken).pipe(
+        return this.cartService.createAnonymousCart(action.anonymousToken).pipe(
           map((cartBase: CartBase) =>
             actions.loadAnonymousCartSuccess({
               cartBase,
@@ -126,7 +128,7 @@ export default class EcommerceEffects {
           filter(([anonToken, accessToken]) => !!anonToken || !!accessToken),
           take(1),
           switchMap(([anonToken, accessToken]) =>
-            this.ecommerceApiService
+            this.cartService
               .updateAnonymousCart(
                 accessToken || anonToken,
                 action.cartBase.id,

--- a/e-commerce/src/app/store/effects.ts
+++ b/e-commerce/src/app/store/effects.ts
@@ -118,6 +118,41 @@ export default class EcommerceEffects {
     ),
   );
 
+  updateAnonymousCart$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(actions.loadUpdateAnonymousCart),
+      switchMap((action) =>
+        combineLatest([this.store.select(selectAnonymousToken), this.store.select(selectAccessToken)]).pipe(
+          filter(([anonToken, accessToken]) => !!anonToken || !!accessToken),
+          take(1),
+          switchMap(([anonToken, accessToken]) =>
+            this.ecommerceApiService
+              .updateAnonymousCart(
+                accessToken || anonToken,
+                action.cartBase.id,
+                action.cartBase.version,
+                action.productId,
+              )
+              .pipe(
+                map((cartBase: CartBase) =>
+                  actions.loadUpdateAnonymousCartSuccess({
+                    cartBase,
+                  }),
+                ),
+                catchError((error) =>
+                  of(
+                    actions.loadUpdateAnonymousCartFailure({
+                      error: error.message,
+                    }),
+                  ),
+                ),
+              ),
+          ),
+        ),
+      ),
+    ),
+  );
+
   refreshAccsessToken$ = createEffect(() =>
     this.actions$.pipe(
       ofType(actions.refreshAccsessToken),

--- a/e-commerce/src/app/store/reducers.ts
+++ b/e-commerce/src/app/store/reducers.ts
@@ -53,6 +53,10 @@ export const ecommerceReducer = createReducer(
   on(actions.loadAnonymousCartSuccess, (state, { cartBase }) => ({ ...state, cartBase, loading: false })),
   on(actions.loadAnonymousCartFailure, (state, { error }) => ({ ...state, error, loading: false })),
   ///
+  on(actions.loadUpdateAnonymousCart, (state) => ({ ...state, loading: true })),
+  on(actions.loadUpdateAnonymousCartSuccess, (state, { cartBase }) => ({ ...state, cartBase, loading: false })),
+  on(actions.loadUpdateAnonymousCartFailure, (state, { error }) => ({ ...state, error, loading: false })),
+  ///
   on(actions.loadRegistration, (state) => ({ ...state, loading: true })),
   on(actions.loadRegistrationSuccess, (state) => ({ ...state, loading: false })),
   on(actions.loadRegistrationFailure, (state, { error }) => ({ ...state, error, loading: false })),


### PR DESCRIPTION
### RSS-ECOMM-4_02: Adding Products to Anonymous Cart with API
**Screenshot:** (optional)
<img width="1710" alt="cart" src="https://github.com/koeebeth/e-commerce/assets/147927216/a209c008-4885-429e-927e-e1e1f2080b1c">

Rationale: 


- Implemented the addition of LineItems to the Anonymous Cart by clicking `Buy` in the Product card
- Wrote a request to update the Anonymous Cart
- Saved the data in the store

**Note**: The change of the `Buy` button and the display of the quantity will be implemented in another PR.

#### Tests(optional)
- 
