### PR TITLE
feat/Add LineItems to Cart from Catalog

### DIFF
--- a/e-commerce/src/app/pages/catalog-page/catalog-page.component.html
+++ b/e-commerce/src/app/pages/catalog-page/catalog-page.component.html
@@ -53,3 +53,4 @@
     </div>
   </div>
 </section>
+<app-loading *ngIf="isLoading$ | async"></app-loading>

--- a/e-commerce/src/app/pages/catalog-page/catalog-page.component.ts
+++ b/e-commerce/src/app/pages/catalog-page/catalog-page.component.ts
@@ -9,17 +9,20 @@ import { ProductsArray } from '../../shared/services/products/productTypes';
 import FilterComponent from './filter/filter.component';
 import SortingComponent from './sorting/sorting.component';
 import SearchingComponent from './searching/searching.component';
-import { selecFilters, selecSort } from '../../store/selectors';
+import { selecFilters, selecSort, selectLoading } from '../../store/selectors';
+import LoadingComponent from '../../shared/components/loading/loading.component';
 
 @Component({
   selector: 'app-catalog-page',
   standalone: true,
-  imports: [CommonModule, CardComponent, FilterComponent, SortingComponent, SearchingComponent],
+  imports: [CommonModule, CardComponent, FilterComponent, SortingComponent, SearchingComponent, LoadingComponent],
   templateUrl: './catalog-page.component.html',
   styleUrl: './catalog-page.component.scss',
 })
 export default class CatalogPageComponent {
   productObjects$!: Observable<ProductsArray | null>;
+
+  isLoading$!: Observable<boolean>;
 
   filters$!: Observable<{ [key: string]: string[] }>;
 
@@ -71,6 +74,8 @@ export default class CatalogPageComponent {
         this.calcShowDots();
       }
     });
+
+    this.isLoading$ = this.store.select(selectLoading);
   }
 
   calcTotalPages() {

--- a/e-commerce/src/app/pages/main/catalog/card/card.component.html
+++ b/e-commerce/src/app/pages/main/catalog/card/card.component.html
@@ -11,7 +11,7 @@
       <div [ngStyle]="originalPriceStyles()" class="price-container">
         <div *ngIf="discountPercnt > 0" class="discount">{{ discountPercnt }}%</div>
         <div class="button-container">
-          <button>
+          <button [disabled]="!!this.lineItem" (click)="addToCart($event)">
             <img src="../../../../../assets/cart.svg" width="10" height="10" alt="cart" />
             <span>Buy</span>
           </button>

--- a/e-commerce/src/app/pages/main/catalog/card/card.component.scss
+++ b/e-commerce/src/app/pages/main/catalog/card/card.component.scss
@@ -118,10 +118,16 @@
             border: 1px solid rgba($color-primary-500, 0.6);
             cursor: pointer;
             transition: 0.3s;
+          }
 
-            &:hover {
-              transform: scale(0.9);
-            }
+          button:not(:disabled):hover {
+            transform: scale(0.9);
+          }
+
+          :disabled {
+            background-color: rgba($color-primary-400, 0.3);
+            color: rgba(255, 255, 255, 0.297);
+            cursor: default;
           }
         }
 

--- a/e-commerce/src/app/pages/main/catalog/catalog.component.html
+++ b/e-commerce/src/app/pages/main/catalog/catalog.component.html
@@ -11,3 +11,4 @@
     <button class="see-more_btn" (click)="onSeeMore()">See more</button>
   </div>
 </section>
+<app-loading *ngIf="isLoading$ | async"></app-loading>

--- a/e-commerce/src/app/pages/main/catalog/catalog.component.ts
+++ b/e-commerce/src/app/pages/main/catalog/catalog.component.ts
@@ -8,16 +8,20 @@ import { AppState } from '../../../store/store';
 import { ProductsArray } from '../../../shared/services/products/productTypes';
 import ButtonComponent from '../../../shared/components/button/button.component';
 import * as actions from '../../../store/actions';
+import LoadingComponent from '../../../shared/components/loading/loading.component';
+import { selectLoading } from '../../../store/selectors';
 
 @Component({
   selector: 'app-catalog',
   standalone: true,
-  imports: [CommonModule, CardComponent, ButtonComponent, RouterLink],
+  imports: [CommonModule, CardComponent, ButtonComponent, RouterLink, LoadingComponent],
   templateUrl: './catalog.component.html',
   styleUrl: './catalog.component.scss',
 })
 export default class CatalogComponent {
   productObjects$!: Observable<ProductsArray | null>;
+
+  isLoading$!: Observable<boolean>;
 
   productResponse!: ProductsArray;
 
@@ -45,6 +49,7 @@ export default class CatalogComponent {
         this.productResponse = products;
       }
     });
+    this.isLoading$ = this.store.select(selectLoading);
   }
 
   onSeeMore() {


### PR DESCRIPTION
### RSS-ECOMM-4_02: Adding Products to Cart with API + save to store
### RSS-ECOMM-4_03: Efficient Loading of Products on Catalog Page
**Screenshot:** (optional)
<img width="1710" alt="add" src="https://github.com/koeebeth/e-commerce/assets/147927216/8cd3cfd8-a755-4365-a469-039af03f7da1">
<img width="1704" alt="add1" src="https://github.com/koeebeth/e-commerce/assets/147927216/b372f7bf-db0e-4a48-9030-d847e9023fd6">

Rationale: 


- Implemented the addition of `LineItems` to the Cart by clicking Buy in the Catalog or Main Page
- Added the disabled button if the card is already in the Cart
- Added loading indicator for the requirement `A loading indicator or some feedback is shown while the API call is in progress` in [RSS-ECOMM-4_02](https://maryanalus.atlassian.net/jira/software/projects/ECP/boards/2?selectedIssue=ECP-99)

#### Tests(optional)
- 
